### PR TITLE
Add . to the template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A quick example:
 
       # Dump only matching users
       - table: users
-        query: "SELECT * FROM users WHERE {{matching_user_id}}"
+        query: "SELECT * FROM users WHERE {{.matching_user_id}}"
         post_actions:
           - "SELECT pg_catalog.setval('users_id_seq', MAX(id) + 1, true) FROM users"
 
@@ -81,7 +81,7 @@ A quick example:
           SELECT purchases.* FROM purchases, users
           WHERE
             purchases.buyer_id = users.id
-            AND {{matching_user_id}}
+            AND {{.matching_user_id}}
 
 
 Currently, these top-level keys are available:


### PR DESCRIPTION
Hi Ali, thanks for this tool! It seems to be the only one of its kind I was able to find.

There a little inaccuracy in the README that took me some time to figure out: according to [`text/template` docs](https://pkg.go.dev/text/template#Template) interpolation need a dot in front, otherwise it's considered function call, which is consistent with an error I was getting 

`level=error name=pdd ts=2024-06-11T06:55:15.90434Z caller=main.go:168 error="template: query:1: function \"id\" not defined"`

when using the following manifest:

```yaml
vars:
  id: "id = 'abc'"

tables:
  - table: entity
    query: "SELECT * FROM entity WHERE {{id}}"
```

Changing it to `{{.id}}` fixed the problem.